### PR TITLE
Removed instructions for adding CUDA to system path

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,1 @@
-How to add CUDA paths to the systems path: append to /home/marius/.bashrc then logout/login:
-
-export CUDA_HOME=/usr/local/cuda-7.5 
-export LD_LIBRARY_PATH=${CUDA_HOME}/lib64 
-export PATH=${CUDA_HOME}/bin:${PATH} 
-
-Then run mexGPUall.m
+Run mexGPUall.m


### PR DESCRIPTION
This has now been done on all the servers automatically (globally, for everyone) so there's no need to do it for each user.