### PR TITLE
proper args on fitTemplates call

### DIFF
--- a/master_file_example.m
+++ b/master_file_example.m
@@ -83,7 +83,7 @@ if strcmp(ops.initialize, 'fromData')
     optimizePeaks(uproj);
 end
 %
-[rez] = fitTemplates(ops, rez, DATA); 
+[rez] = fitTemplates(ops, rez, DATA, WUinit); 
 
 %
 % extracts final spike times (overlapping extraction)


### PR DESCRIPTION
fitTemplates seems to have changed. This patch assumes that this WUinit is the same as what fitTemplates requires.