### PR TITLE
Replace all instances of gather() with gather_try()

### DIFF
--- a/driftCorrection/clusterAndDriftCorrection.m
+++ b/driftCorrection/clusterAndDriftCorrection.m
@@ -84,7 +84,7 @@ for i = 1:10
         
         % determine cluster assignment for this iteration
         [max_cf, id] = max(cf(:,:,2), [], 2);
-        id = gather(id);
+        id = gather_try(id);
         L = gpuArray.zeros(Nfilt, nSpikes, 'single');
         L(id' + [0:Nfilt:(Nfilt*nSpikes-1)]) = 1;
         dWU = dWU + L * clips;
@@ -115,7 +115,7 @@ nt0 = 61;
 Urec= permute(Urec, [2 1 3]);
 Wrec = reshape(wPCA * Urec(:,:), nt0, Nchan, Nfilt);
 
-Wrec = gather(Wrec);
+Wrec = gather_try(Wrec);
 Nrank = 3;
 W = zeros(nt0, Nfilt, Nrank, 'single');
 U = zeros(Nchan, Nfilt, Nrank, 'single');
@@ -130,7 +130,7 @@ end
 
 Uinit = U;
 Winit = W;
-mu = gather(single(mu));
+mu = gather_try(single(mu));
 muinit = mu;
 
 WUinit = zeros(nt0, Nchan, Nfilt);

--- a/driftCorrection/collectRawClips.m
+++ b/driftCorrection/collectRawClips.m
@@ -150,7 +150,7 @@ end
 
 if ops.whiteningRange<Inf
     ops.whiteningRange = min(ops.whiteningRange, Nchan);
-    Wrot = whiteningLocal(gather(CC), yc, xc, ops.whiteningRange);
+    Wrot = whiteningLocal(gather_try(CC), yc, xc, ops.whiteningRange);
 else
     %
     [E, D] 	= svd(CC);

--- a/fullMPMU.m
+++ b/fullMPMU.m
@@ -29,7 +29,7 @@ for i = 1:Nrank
     for j = 1:Nrank
         utu0 = U0(:,:,i)' * U0(:,:,j);
         if ops.GPU
-            wtw0 =  gather(mexWtW2(Params, W(:,:,i), W(:,:,j), utu0));
+            wtw0 =  gather_try(mexWtW2(Params, W(:,:,i), W(:,:,j), utu0));
         else
             wtw0 =  getWtW2(Params, W(:,:,i), W(:,:,j), utu0);
             wtw0 = permute(wtw0, [2 3 1]);
@@ -56,7 +56,7 @@ if ~ops.GPU
 end
 % mWtW = mWtW - diag(diag(mWtW));
 
-% rez.WtW = gather(WtW);
+% rez.WtW = gather_try(WtW);
 %
 clear wtw0 utu0 U0
 %
@@ -165,7 +165,7 @@ for ibatch = 1:Nbatch
             coefs           = reshape(permute(coefs, [3 1 2]), [], numel(st));
             coefs           = coefs .* maskPC(:, id+1);
             iCoefs          = reshape(find(maskPC(:, id+1)>0), 3*nNeighPC, []);
-            rez.cProjPC(irun + (1:numel(st)), :) = gather(coefs(iCoefs)');
+            rez.cProjPC(irun + (1:numel(st)), :) = gather_try(coefs(iCoefs)');
         end
         if ~isempty(ops.nNeigh)
             % template coefficients

--- a/initialize/optimizePeaks.m
+++ b/initialize/optimizePeaks.m
@@ -73,7 +73,7 @@ for i = 1:10
         
         [max_cf, id] = max(cf, [], 2);
         
-        id = gather(id);
+        id = gather_try(id);
         %        x = ci([1:nSpikesPerBatch] + nSpikesPerBatch * (id-1)')' - mu(id) .* lam(id);
         idT(:,ibatch) = id;
         
@@ -105,7 +105,7 @@ Urec = reshape(U, Nchan, size(wPCA,2), Nfilt);
 Urec= permute(Urec, [2 1 3]);
 Wrec = reshape(wPCA * Urec(:,:), nt0, Nchan, Nfilt);
 
-Wrec = gather(Wrec);
+Wrec = gather_try(Wrec);
 Nrank = 3;
 W = zeros(nt0, Nfilt, Nrank, 'single');
 U = zeros(Nchan, Nfilt, Nrank, 'single');
@@ -122,7 +122,7 @@ end
 
 Uinit = U;
 Winit = W;
-mu = gather(single(mu));
+mu = gather_try(single(mu));
 muinit = mu;
 
 WUinit = zeros(nt0, Nchan, Nfilt);

--- a/mainLoop/update_params.m
+++ b/mainLoop/update_params.m
@@ -2,13 +2,13 @@ function  [W, U, mu, UtU] = update_params(mu, W, U, dWUtot, nspikes)
 
 [Nchan, Nfilt, Nrank] = size(U);
 
-dWUtotCPU = gather(dWUtot);
+dWUtotCPU = gather_try(dWUtot);
 ntot = sum(nspikes,2);
 
 for k = 1:Nfilt
     if ntot(k)>5
-        [Uall, Sv, Vall] = svd(gather(dWUtotCPU(:,:,k)), 0);
         
+        [Uall, Sv, Vall] = svd(gather_try(dWUtotCPU(:,:,k)), 0);
         Sv = diag(Sv);
         sumSv2 = sum(Sv(1:Nrank).^2).^.5;
         for irank = 1:Nrank

--- a/preprocessData.m
+++ b/preprocessData.m
@@ -175,7 +175,7 @@ end
 
 if ops.whiteningRange<Inf
     ops.whiteningRange = min(ops.whiteningRange, Nchan);
-    Wrot = whiteningLocal(gather(CC), yc, xc, ops.whiteningRange);
+    Wrot = whiteningLocal(gather_try(CC), yc, xc, ops.whiteningRange);
 else
     %
     [E, D] 	= svd(CC);

--- a/tests/gather_mean_spikes.m
+++ b/tests/gather_mean_spikes.m
@@ -63,7 +63,7 @@ for ibatch = 1:Nbatch
             inds = repmat(st', nt0, 1) + repmat(ts, 1, numel(st));
             
             Wraw(:,:,iNN) = Wraw(:,:,iNN) + ...
-                gather(squeeze(sum(reshape(dataRAW(inds, :), nt0, numel(st), Nchans),2)));
+                gather_try(squeeze(sum(reshape(dataRAW(inds, :), nt0, numel(st), Nchans),2)));
         end
     end
     


### PR DESCRIPTION
This allows KiloSort to run on systems without the parallel computing toolbox installed. Looks like gather_try() in KiloSort was written to handle such a situation, but gather() was not replaced with gather_try() in several places.