### PR TITLE
sets gpu random seed for useGPU case

### DIFF
--- a/eMouse/make_eMouseData.m
+++ b/eMouse/make_eMouseData.m
@@ -12,6 +12,11 @@ chsmooth  = 1; % smooth the noise across channels too, with this sig (increase t
 amp_std   = .25; % standard deviation of single spike amplitude variability (increase to make it harder, technically std of gamma random variable of mean 1) (.25)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+if useGPU
+    parallel.gpu.rng('default');
+    parallel.gpu.rng(10191);  % set the seed of the random number generator
+end
+
 rng('default');
 rng(101);  % set the seed of the random number generator
 


### PR DESCRIPTION
Allows for deterministic creation of eMouse output. Leaving this file as is and setting `useGPU=1`, sim_binary.dat should now have the following checksums:

- SHA1: `8ddf44485467ef8dc7128bf5eb165fd51866d9c5`
- MD5: `3f810a1d4b9cb1a6c84d846e58b4fc6b`
- SHA256: `7c0629422a8bc1b588f4942829687a392495f1b8f6e449009d278cb8e0b6b6ab`
