### PR TITLE
Change data in 'spike_clusters.npy' to int32 instead of uint32

### DIFF
--- a/finalPass/rezToPhy.m
+++ b/finalPass/rezToPhy.m
@@ -78,9 +78,9 @@ if ~isempty(savePath)
     writeNPY(spikeTimes, fullfile(savePath, 'spike_times.npy'));
     writeNPY(uint32(spikeTemplates-1), fullfile(savePath, 'spike_templates.npy')); % -1 for zero indexing
     if size(rez.st3,2)>4
-        writeNPY(uint32(spikeClusters-1), fullfile(savePath, 'spike_clusters.npy')); % -1 for zero indexing
+        writeNPY(int32(spikeClusters-1), fullfile(savePath, 'spike_clusters.npy')); % -1 for zero indexing
     else
-        writeNPY(uint32(spikeTemplates-1), fullfile(savePath, 'spike_clusters.npy')); % -1 for zero indexing
+        writeNPY(int32(spikeTemplates-1), fullfile(savePath, 'spike_clusters.npy')); % -1 for zero indexing
     end
     writeNPY(amplitudes, fullfile(savePath, 'amplitudes.npy'));
     writeNPY(templates, fullfile(savePath, 'templates.npy'));


### PR DESCRIPTION
This commit brings the behavior of `rezToPhy.m` in-line with the documentation.
The documentation and phy's template gui both expect `int32` cluster ids, but
before this commit `rezToPhy.m` wrote cluster ids as `uint32`.