### PR TITLE
Fix outputs in rezToPhy.m

### DIFF
--- a/finalPass/rezToPhy.m
+++ b/finalPass/rezToPhy.m
@@ -29,8 +29,10 @@ end
 spikeTimes = uint64(rez.st3(:,1));
 % [spikeTimes, ii] = sort(spikeTimes);
 spikeTemplates = uint32(rez.st3(:,2));
+clusterIDs = spikeTemplates;
 if size(rez.st3,2)>4
     spikeClusters = uint32(1+rez.st3(:,5));
+    clusterIDs = spikeClusters;
 end
 amplitudes = rez.st3(:,3);
 


### PR DESCRIPTION
The second output argument, clusterIDs, is now appropriately assigned, and calls to rezToPhy that assign outputs to workspace variables no longer produce errors.

Previously, the following error would be produced:

```
>> [spikeTimes, clusterIDs, amplitudes, templates, templateFeatures, ...
templateFeatureInds, pcFeatures, pcFeatureInds] = rezToPhy(rez, savePath);

Output argument "clusterIDs" (and maybe others) not assigned during
call to "rezToPhy".
```