### PR TITLE
feat: add support for 3-D probe geometry using zcoords

### DIFF
--- a/configFiles/createChannelMapFile.m
+++ b/configFiles/createChannelMapFile.m
@@ -44,3 +44,45 @@ save('C:\DATA\Spikes\Piroska\chanMap.mat', ...
 % number" of channel groups at which to set the threshold. So if a template
 % occupies more than this many channel groups, it will not be restricted to
 % a single channel group. 
+
+%% Example: dual-sided / 3-D probe with zcoords
+%
+% For probes that have recording sites on two faces (or any geometry with a
+% meaningful z-component) you can now include a 'zcoords' variable in the
+% chanMap.mat file.  KiloSort will use the full 3-D Euclidean distance for:
+%   - local whitening neighbourhood (whiteningLocal)
+%   - drift-correction channel covariance (clusterAndDriftCorrection)
+%   - spatial interpolation kernel (shift_matrix / shift_data)
+%
+% When exporting to Phy (rezToPhy), the 3-D positions are projected to 2-D
+% as:  xcoords_2d = xcoords + zcoords
+%      ycoords_2d = ycoords
+% This horizontally separates shanks by their z-depth so Phy's channel
+% map viewer shows each face as a distinct column.
+%
+% If 'zcoords' is absent, KiloSort falls back to all-zeros (2-D behaviour).
+
+Nchannels = 64;                     % 32 sites per face
+connected = true(Nchannels, 1);
+chanMap   = 1:Nchannels;
+chanMap0ind = chanMap - 1;
+kcoords   = ones(Nchannels, 1);
+
+% Face A (z = 0 µm): sites 1–32
+xcoords_A = repmat([0 16]', 16, 1);        % two columns, 16 µm apart
+ycoords_A = sort(repmat((0:15)*20, 1, 2)');  % 20 µm pitch along shank
+zcoords_A = zeros(32, 1);                   % face A is at z = 0
+
+% Face B (z = 25 µm): sites 33–64
+xcoords_B = repmat([0 16]', 16, 1);
+ycoords_B = sort(repmat((0:15)*20, 1, 2)');
+zcoords_B = 25 * ones(32, 1);              % face B is at z = 25 µm
+
+xcoords = [xcoords_A; xcoords_B];
+ycoords = [ycoords_A; ycoords_B];
+zcoords = [zcoords_A; zcoords_B];
+
+fs = 30000;
+save('/path/to/chanMap_dual_sided.mat', ...
+    'chanMap', 'connected', 'xcoords', 'ycoords', 'zcoords', ...
+    'kcoords', 'chanMap0ind', 'fs')

--- a/driftCorrection/clusterAndDriftCorrection.m
+++ b/driftCorrection/clusterAndDriftCorrection.m
@@ -33,7 +33,9 @@ uBase = uBase(1:ncurr, :);
 % compute covariance matrix
 sigDrift = 15;
 sigShift = 20;
-chanDists= bsxfun(@minus, rez.yc, rez.yc').^2 + bsxfun(@minus, rez.xc, rez.xc').^2;
+% 3-D channel distances: includes z so opposite-face channels decouple naturally
+chanDists= bsxfun(@minus, rez.yc, rez.yc').^2 + bsxfun(@minus, rez.xc, rez.xc').^2 ...
+         + bsxfun(@minus, rez.zc, rez.zc').^2;
 iCovChans = my_inv(exp(-chanDists/(2*sigDrift^2)), 1e-6);
 
 Nfilt = ops.Nfilt;
@@ -47,9 +49,9 @@ deltay = zeros(ops.Nchan, numel(indBatch));
 
 for i = 1:10
     % resample spatial masks up and down
-    Uup   = shift_data(reshape(U, ops.Nchan, []),  sigShift, rez.yc, rez.xc, iCovChans, sigDrift, rez.Wrot);
+    Uup   = shift_data(reshape(U, ops.Nchan, []),  sigShift, rez.yc, rez.xc, rez.zc, iCovChans, sigDrift, rez.Wrot);
     Uup   = reshape(Uup, size(U));
-    Udown = shift_data(reshape(U, ops.Nchan, []), -sigShift, rez.yc, rez.xc, iCovChans, sigDrift, rez.Wrot);
+    Udown = shift_data(reshape(U, ops.Nchan, []), -sigShift, rez.yc, rez.xc, rez.zc, iCovChans, sigDrift, rez.Wrot);
     Udown = reshape(Udown, size(U));
         
     mu = repmat(mu, 3, 1);
@@ -66,7 +68,7 @@ for i = 1:10
         clips = reshape(clips, ops.Nchan, []);
         
         % resample clips by the delta y
-        clips = shift_data(clips, deltay(:, ibatch), rez.yc, rez.xc, iCovChans, sigDrift, rez.Wrot);        
+        clips = shift_data(clips, deltay(:, ibatch), rez.yc, rez.xc, rez.zc, iCovChans, sigDrift, rez.Wrot);
         clips = reshape(clips, size(U,1), [])';
         
         ci = clips * [Udown U Uup];

--- a/driftCorrection/collectRawClips.m
+++ b/driftCorrection/collectRawClips.m
@@ -10,16 +10,23 @@ if ~isempty(ops.chanMap)
             chanMapConn = chanMap(connected>1e-6);
             xc = xcoords(connected>1e-6);
             yc = ycoords(connected>1e-6);
+            if exist('zcoords', 'var')
+                zc = zcoords(connected>1e-6);
+            else
+                zc = zeros(numel(chanMapConn), 1);
+            end
         catch
             chanMapConn = 1+chanNums(connected>1e-6);
             xc = zeros(numel(chanMapConn), 1);
             yc = [1:1:numel(chanMapConn)]';
+            zc = zeros(numel(chanMapConn), 1);
         end
     else
         chanMap = ops.chanMap;
         chanMapConn = ops.chanMap;
         xc = zeros(numel(chanMapConn), 1);
         yc = [1:1:numel(chanMapConn)]';
+        zc = zeros(numel(chanMapConn), 1);
         connected = true(numel(chanMap), 1);        
     end
 else
@@ -29,6 +36,7 @@ else
     chanMapConn = 1:ops.Nchan;    
     xc = zeros(numel(chanMapConn), 1);
     yc = [1:1:numel(chanMapConn)]';
+    zc = zeros(numel(chanMapConn), 1);
 end
 if ~exist('kcoords', 'var')
     kcoords = ones(ops.Nchan, 1);
@@ -38,6 +46,7 @@ NT = ops.NT ;
 
 rez.xc = xc;
 rez.yc = yc;
+rez.zc = zc;
 rez.connected   = connected;
 rez.ops         = ops;
 rez.ops.chanMap = chanMap;
@@ -150,7 +159,7 @@ end
 
 if ops.whiteningRange<Inf
     ops.whiteningRange = min(ops.whiteningRange, Nchan);
-    Wrot = whiteningLocal(gather_try(CC), yc, xc, ops.whiteningRange);
+    Wrot = whiteningLocal(gather_try(CC), yc, xc, zc, ops.whiteningRange);
 else
     %
     [E, D] 	= svd(CC);

--- a/driftCorrection/shift_data.m
+++ b/driftCorrection/shift_data.m
@@ -1,7 +1,4 @@
-function data = shift_data(data, dy, ycoords, xcoords, iCovChans, sigDrift, Wrot)
+function data = shift_data(data, dy, ycoords, xcoords, zcoords, iCovChans, sigDrift, Wrot)
 
-shiftM = shift_matrix(dy, ycoords, xcoords, iCovChans, sigDrift, Wrot);
+shiftM = shift_matrix(dy, ycoords, xcoords, zcoords, iCovChans, sigDrift, Wrot);
 data   = shiftM * data;
-
-
-

--- a/driftCorrection/shift_matrix.m
+++ b/driftCorrection/shift_matrix.m
@@ -1,11 +1,15 @@
-function shiftM = shift_matrix(dy, ycoords, xcoords, iCovChans, sig, Wrot)
-
+function shiftM = shift_matrix(dy, ycoords, xcoords, zcoords, iCovChans, sig, Wrot)
+% shift_matrix  Build a channel-interpolation matrix that shifts data by dy
+%               along the probe insertion axis (y).
+%
+%   zcoords contributes to the Gaussian distance kernel so that channels
+%   on opposite faces/shanks are correctly decoupled.  Drift is modelled
+%   only along ycoords; zcoords is treated as static.
 
 yminusy = bsxfun(@minus, ycoords - dy, ycoords').^2 + ...
-    bsxfun(@minus, xcoords , xcoords').^2;
+    bsxfun(@minus, xcoords , xcoords').^2 + ...
+    bsxfun(@minus, zcoords , zcoords').^2;
 
 newSamp = exp(- yminusy/(2*sig^2));
 
 shiftM = Wrot * ((newSamp * iCovChans)/Wrot);
-
-

--- a/finalPass/rezToPhy.m
+++ b/finalPass/rezToPhy.m
@@ -49,6 +49,12 @@ Nchan = rez.ops.Nchan;
 connected   = rez.connected(:);
 xcoords     = rez.xcoords(:);
 ycoords     = rez.ycoords(:);
+% zcoords: present for 3-D probes (e.g. double-sided shanks), else zeros
+if isfield(rez, 'zcoords')
+    zcoords = rez.zcoords(:);
+else
+    zcoords = zeros(size(xcoords));
+end
 chanMap     = rez.ops.chanMap(:);
 chanMap0ind = chanMap - 1;
 
@@ -91,9 +97,13 @@ if ~isempty(savePath)
     chanMap0ind = int32(chanMap0ind);
     
     writeNPY(chanMap0ind(conn), fullfile(savePath, 'channel_map.npy'));
-    %writeNPY(connected, fullfile(savePath, 'connected.npy'));
-%     writeNPY(Fs, fullfile(savePath, 'Fs.npy'));
-    writeNPY([xcoords(conn) ycoords(conn)], fullfile(savePath, 'channel_positions.npy'));
+    % Project 3-D geometry to 2-D for Phy's channel map viewer:
+    %   xcoords_2d = xcoords + zcoords  (shifts each shank horizontally by z-depth)
+    %   ycoords_2d = ycoords            (depth axis unchanged)
+    % For 2-D probes zcoords is all-zeros so this is a no-op.
+    xcoords_2d = xcoords + zcoords;
+    ycoords_2d = ycoords;
+    writeNPY([xcoords_2d(conn) ycoords_2d(conn)], fullfile(savePath, 'channel_positions.npy'));
     
     writeNPY(templateFeatures, fullfile(savePath, 'template_features.npy'));
     writeNPY(templateFeatureInds'-1, fullfile(savePath, 'template_feature_ind.npy'));% -1 for zero indexing

--- a/preProcess/whiteningLocal.m
+++ b/preProcess/whiteningLocal.m
@@ -1,8 +1,15 @@
-function Wrot = whiteningLocal(CC, yc, xc, nRange)
+function Wrot = whiteningLocal(CC, yc, xc, zc, nRange)
+% whiteningLocal  Compute a local whitening matrix using nearest channels.
+%
+%   Wrot = whiteningLocal(CC, yc, xc, zc, nRange)
+%
+%   Channels are ranked by 3-D Euclidean distance so that probes with a
+%   meaningful z-component (e.g. double-sided shanks) correctly prefer
+%   geometrically close neighbours.  For 2-D probes pass zc = zeros(N,1).
 
 Wrot = zeros(size(CC,1), size(CC,1));
 for j = 1:size(CC,1)
-    ds          = (xc - xc(j)).^2 + (yc - yc(j)).^2;
+    ds          = (xc - xc(j)).^2 + (yc - yc(j)).^2 + (zc - zc(j)).^2;
     [~, ilocal] = sort(ds, 'ascend');
     ilocal      = ilocal(1:nRange);
     

--- a/preprocessData.m
+++ b/preprocessData.m
@@ -15,10 +15,16 @@ if ~isempty(ops.chanMap)
             chanMapConn = chanMap(connected>1e-6);
             xc = xcoords(connected>1e-6);
             yc = ycoords(connected>1e-6);
+            if exist('zcoords', 'var')
+                zc = zcoords(connected>1e-6);
+            else
+                zc = zeros(numel(chanMapConn), 1);
+            end
         catch
             chanMapConn = 1+chanNums(connected>1e-6);
             xc = zeros(numel(chanMapConn), 1);
             yc = [1:1:numel(chanMapConn)]';
+            zc = zeros(numel(chanMapConn), 1);
         end
         ops.Nchan    = getOr(ops, 'Nchan', sum(connected>1e-6));
         ops.NchanTOT = getOr(ops, 'NchanTOT', numel(connected));
@@ -30,6 +36,7 @@ if ~isempty(ops.chanMap)
         chanMapConn = ops.chanMap;
         xc = zeros(numel(chanMapConn), 1);
         yc = [1:1:numel(chanMapConn)]';
+        zc = zeros(numel(chanMapConn), 1);
         connected = true(numel(chanMap), 1);      
         
         ops.Nchan    = numel(connected);
@@ -42,6 +49,7 @@ else
     chanMapConn = 1:ops.Nchan;    
     xc = zeros(numel(chanMapConn), 1);
     yc = [1:1:numel(chanMapConn)]';
+    zc = zeros(numel(chanMapConn), 1);
 end
 if exist('kcoords', 'var')
     kcoords = kcoords(connected);
@@ -54,12 +62,19 @@ NT       = ops.NT ;
 rez.ops         = ops;
 rez.xc = xc;
 rez.yc = yc;
-if exist('xcoords')
+rez.zc = zc;
+if exist('xcoords', 'var')
    rez.xcoords = xcoords;
    rez.ycoords = ycoords;
+   if exist('zcoords', 'var')
+       rez.zcoords = zcoords;
+   else
+       rez.zcoords = zeros(numel(xcoords), 1);
+   end
 else
    rez.xcoords = xc;
    rez.ycoords = yc;
+   rez.zcoords = zc;
 end
 rez.connected   = connected;
 rez.ops.chanMap = chanMap;
@@ -180,7 +195,7 @@ end
 
 if ops.whiteningRange<Inf
     ops.whiteningRange = min(ops.whiteningRange, Nchan);
-    Wrot = whiteningLocal(gather_try(CC), yc, xc, ops.whiteningRange);
+    Wrot = whiteningLocal(gather_try(CC), yc, xc, zc, ops.whiteningRange);
 else
     %
     [E, D] 	= svd(CC);


### PR DESCRIPTION
# 3D Channel Geometry Support for KiloSort

## Background

KiloSort currently only handles 2D probe geometry (`xcoords`/`ycoords`). For double-sided probes (e.g., IMEC Neuropixels 2.0, NeuroNexus Buzsaki64 variants, or custom dual-sided shanks), there is a meaningful z-component that affects nearest-channel computations, whitening locality, and drift correction.

**Goal**: Propagate an optional `zcoords` through the entire internal pipeline using proper 3D Euclidean distance, while projecting to 2D (x + z-offset shank spread) **only** at the `rezToPhy` export step so Phy's 2D viewer remains interpretable.

---

## User Review Required

> [!IMPORTANT]
> **Projection strategy for Phy export**: The user's requested approach is to shift in the 2D plane the shank by the amount of z-distance. The plan below implements this as:
> `xcoords_2d = xcoords + zcoords` (x-offset by z), `ycoords_2d = ycoords` unchanged.
> If your probe has multiple distinct z-planes (e.g., shanks at z = 0, 200, 400 µm), this will spread them horizontally. Please confirm this matches your intent, or specify an alternative (e.g., collapse onto y-axis with a different formula).

> [!IMPORTANT]
> **Drift correction is y-axis only**: The drift correction in `clusterAndDriftCorrection.m` and `shift_matrix.m` shifts channels along `ycoords` (the depth axis). The z-component affects the *distance metric* (so nearby channels on opposite faces are correctly weighted) but is **not** independently drifted. This is the correct assumption for shanks that drift along their insertion axis (y), not laterally.

> [!NOTE]
> **Backward compatibility**: If `zcoords` is absent from `chanMap.mat`, all modified files fall back to `zc = zeros(Nchan, 1)` (i.e., old 2D behavior). No existing channel map files need to change.

---

## Open Questions

> [!WARNING]
> For the `shift_matrix.m` drift kernel, the current formula shifts channels by `dy` along the y-axis and uses `exp(-dist^2 / (2*sig^2))` to interpolate. With 3D geometry the distance now includes z. This means shanks on opposite sides of the probe (large z-separation) will be correctly decoupled from each other during drift interpolation. Is this the desired behavior, or should drift always be applied within the same z-plane/shank only?

---

## Proposed Changes

### 1. `preprocessData.m` — Load & store `zc`/`zcoords`

#### [MODIFY] [preprocessData.m](file:///home/cornell/Desktop/phd/KiloSort/preprocessData.m)

- In the `load(ops.chanMap)` branch: read `zcoords` if present, filter by `connected` → `zc`; else `zc = zeros(...)`.
- In the fallback numeric chanMap branch: `zc = zeros(...)`.
- In the no-chanMap branch: `zc = zeros(...)`.
- Store `rez.zc`, `rez.zcoords`.
- Pass `zc` as third coordinate argument to `whiteningLocal(...)`.

---

### 2. `driftCorrection/collectRawClips.m` — Same as preprocessData for the drift-correction path

#### [MODIFY] [collectRawClips.m](file:///home/cornell/Desktop/phd/KiloSort/driftCorrection/collectRawClips.m)

- Mirror the same `zc`/`zcoords` loading & fallback logic.
- Store `rez.zc`, pass `zc` to `whiteningLocal(...)`.

---

### 3. `preProcess/whiteningLocal.m` — 3D distance for nearest channel

#### [MODIFY] [whiteningLocal.m](file:///home/cornell/Desktop/phd/KiloSort/preProcess/whiteningLocal.m)

- Signature: `whiteningLocal(CC, yc, xc, nRange)` → `whiteningLocal(CC, yc, xc, zc, nRange)`
- Distance: `ds = (xc-xc(j)).^2 + (yc-yc(j)).^2 + (zc-zc(j)).^2`
- All call sites updated accordingly.

---

### 4. `driftCorrection/clusterAndDriftCorrection.m` — 3D channel covariance & shift

#### [MODIFY] [clusterAndDriftCorrection.m](file:///home/cornell/Desktop/phd/KiloSort/driftCorrection/clusterAndDriftCorrection.m)

- `chanDists` now includes the z-term: `+ bsxfun(@minus, rez.zc, rez.zc').^2`
- Pass `rez.zc` to `shift_data(...)`.

---

### 5. `driftCorrection/shift_data.m` — Forward `zcoords`

#### [MODIFY] [shift_data.m](file:///home/cornell/Desktop/phd/KiloSort/driftCorrection/shift_data.m)

- Signature: `shift_data(data, dy, ycoords, xcoords, iCovChans, sigDrift, Wrot)` → add `zcoords`
- Forward `zcoords` to `shift_matrix(...)`.

---

### 6. `driftCorrection/shift_matrix.m` — 3D distance for drift interpolation kernel

#### [MODIFY] [shift_matrix.m](file:///home/cornell/Desktop/phd/KiloSort/driftCorrection/shift_matrix.m)

- Signature: add `zcoords` parameter.
- Distance formula: add `+ bsxfun(@minus, zcoords, zcoords').^2` to the existing x/y terms.
- The `dy` shift is applied only to ycoords (drift axis), z is static.

---

### 7. `finalPass/rezToPhy.m` — 2D projection for Phy export

#### [MODIFY] [rezToPhy.m](file:///home/cornell/Desktop/phd/KiloSort/finalPass/rezToPhy.m)

- Pull `rez.zcoords` if available (else zeros).
- Compute 2D projection: `xcoords_2d = xcoords + zcoords; ycoords_2d = ycoords`
  (shifts shank in x by its z depth, spreading shanks horizontally in the Phy viewer).
- Write `[xcoords_2d(conn) ycoords_2d(conn)]` to `channel_positions.npy`.

---

### 8. `configFiles/createChannelMapFile.m` — Document the new optional field

#### [MODIFY] [createChannelMapFile.m](file:///home/cornell/Desktop/phd/KiloSort/configFiles/createChannelMapFile.m)

- Add a documented example section showing how to create a `chanMap.mat` with `zcoords` for a dual-sided probe.

---

## Verification Plan

### Manual Code Review
- Confirm all call sites of `whiteningLocal`, `shift_data`, `shift_matrix` are updated.
- Confirm fallback to 2D (no `zcoords` in file) works correctly.
- Confirm `rezToPhy` writes valid 2D positions that render correctly in Phy (Nx2 float array).

### Functional Test (User-side)
- Run KiloSort with an existing 2D `chanMap.mat` (no `zcoords`) and verify no regression.
- Run with a 3D `chanMap.mat` (with `zcoords`) and confirm `channel_positions.npy` has x-shifted shanks.
